### PR TITLE
PIT-13: Refactor Excel export logic and add office validation test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@
 # Playwright
 node_modules/
 /test-results/
-/resultados-exportados/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
 
 /generated/prisma
+
+/resultados-exportados/
+
+.DS_Store

--- a/src/types/excelInterfaces.ts
+++ b/src/types/excelInterfaces.ts
@@ -17,3 +17,13 @@ export interface ExcelValidacion {
   idAddress?: string
   nombreOficina?: string
 }
+
+export interface ExportConfig<T> {
+  data: T[]
+  nombreBase: string
+  headers: string[]
+  nombreHoja?: string
+  extraerCampos: CampoExtractor<T>[]
+}
+
+export type CampoExtractor<T> = (item: T) => string | number | boolean | undefined

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import * as XLSX from 'xlsx'
 import * as fs from 'fs'
 import * as path from 'path'
-import { ExcelValidacion } from '@/types/excelInterfaces'
+import { ExcelValidacion, ExportConfig } from '@/types/excelInterfaces'
 
 export function parseNumber(value: string | undefined, defaultValue: number): number {
   const parsed = Number(value)
@@ -33,93 +33,29 @@ function getTimestamp(): string {
   return `${yyyy}${MM}${dd}_${hh}${mm}${ss}`
 }
 
-export function exportarResultadosValidarAddressIdAExcel(data: ExcelValidacion[], nombreBase: string) {
+export function exportarResultadosGenerico<T>(config: ExportConfig<T>) {
+  const { data, nombreBase, headers, extraerCampos, nombreHoja = 'Resultados' } = config
+
   // 1. Crear libro y hoja
   const libro = XLSX.utils.book_new()
-  const hoja = XLSX.utils.aoa_to_sheet([]) // hoja vacía para llenarla a mano
+  const hoja = XLSX.utils.aoa_to_sheet([headers])
 
-  // 2. Encabezados (orden manual)
-  const headers = ['NRO', 'DIRECCIÓN ENVIADA', 'DIRECCIÓN OBTENIDA', 'UBIGEO', 'POLÍGONO OBTENIDO', 'TRACKING', 'SERVICIO CÓDIGO', 'NOMBRE CLIENTE']
-  XLSX.utils.sheet_add_aoa(hoja, [headers], { origin: 'A1' })
-
-  // 3. Filas de datos (orden manual)
-  const rows = data.map((r: ExcelValidacion) => [
-    r.nro,
-    r.direccionEnviada,
-    r.direccionObtenida,
-    r.ubigeo,
-    r.poligonoObtenido,
-    r.tracking,
-    r.servicioCodigo,
-    r.nombreCliente
-  ])
+  // 2. Filas de datos
+  const rows = data.map((item) => extraerCampos.map((fn) => fn(item)))
   XLSX.utils.sheet_add_aoa(hoja, rows, { origin: 'A2' })
 
-  // 4. Ajustar anchos
-  const colWidths = headers.map((h) => ({ wch: Math.max(h.length, 20) }))
-  hoja['!cols'] = colWidths
+  // 3. Ajustar anchos
+  hoja['!cols'] = headers.map((h) => ({ wch: Math.max(h.length, 20) }))
 
-  // 5. Adjuntar hoja al libro
-  XLSX.utils.book_append_sheet(libro, hoja, 'Resultados Validación')
+  // 4. Adjuntar hoja al libro
+  XLSX.utils.book_append_sheet(libro, hoja, nombreHoja)
 
-  // 6. Guardar archivo
+  // 5. Guardar archivo
   if (!fs.existsSync('resultados-exportados')) fs.mkdirSync('resultados-exportados')
   const timestamp = getTimestamp()
   const nombreArchivo = `${nombreBase}_${timestamp}.xlsx`
   const ruta = path.join('resultados-exportados', nombreArchivo)
   XLSX.writeFile(libro, ruta)
-  console.log(`✅ Resultados exportados a: ${ruta}`)
-}
 
-export function exportarResultadosValidarOficinasAExcel(data: ExcelValidacion[], nombreBase: string) {
-  // 1. Crear libro y hoja
-  const libro = XLSX.utils.book_new()
-  const hoja = XLSX.utils.aoa_to_sheet([]) // hoja vacía para llenarla a mano
-
-  // 2. Encabezados (orden manual)
-  const headers = [
-    'NRO',
-    'LONGITUD ENVIADA',
-    'LONGITUD OBTENIDA',
-    'LATITUD ENVIADA',
-    'LATITUD OBTENIDA',
-    'DIRECCIONES',
-    'CODUBIGEO ENVIADO',
-    'CODUBIGEO OBTENIDO',
-    'ES OFICINA?',
-    'ID ADDRESS',
-    'NOMBRE OFICINA'
-  ]
-  XLSX.utils.sheet_add_aoa(hoja, [headers], { origin: 'A1' })
-
-  // 3. Filas de datos (orden manual)
-  const rows = data.map((r: ExcelValidacion) => [
-    r.nro,
-    r.longitudeEnviada,
-    r.longitudeObtenida,
-    r.latitudeEnviada,
-    r.latitudeObtenida,
-    r.direccionEnviada,
-    r.codUbigeoEnviado,
-    r.codUbigeoObtenido,
-    r.isOficina,
-    r.idAddress,
-    r.nombreOficina
-  ])
-  XLSX.utils.sheet_add_aoa(hoja, rows, { origin: 'A2' })
-
-  // 4. Ajustar anchos
-  const colWidths = headers.map((h) => ({ wch: Math.max(h.length, 20) }))
-  hoja['!cols'] = colWidths
-
-  // 5. Adjuntar hoja al libro
-  XLSX.utils.book_append_sheet(libro, hoja, 'Resultados Validación Oficinas')
-
-  // 6. Guardar archivo
-  if (!fs.existsSync('resultados-exportados')) fs.mkdirSync('resultados-exportados')
-  const timestamp = getTimestamp()
-  const nombreArchivo = `${nombreBase}_${timestamp}.xlsx`
-  const ruta = path.join('resultados-exportados', nombreArchivo)
-  XLSX.writeFile(libro, ruta)
   console.log(`✅ Resultados exportados a: ${ruta}`)
 }

--- a/tests/api/creacionTrancking/crearTrackingsLima.spec.ts
+++ b/tests/api/creacionTrancking/crearTrackingsLima.spec.ts
@@ -45,7 +45,11 @@ test('Crear trackings en la sede de Lima, 1 request por body (Iterativo)', async
     const fila: any = datos[i]
 
     const direccion = fila['DIRECCIONES']
-    const idUbigeo = parseInt(fila['IDUBIGEO']) || 0
+
+    const codUbigeo = fila['IDUBIGEO'].toString().padStart(6, '0')
+    expect(codUbigeo.length).toBe(6)
+    const idUbigeo = parseInt(codUbigeo) || 0
+
     const codigoOptitrack = baseCodigoOptitrack + i - 1
 
     // Puedes ajustar los demás parámetros si quieres que también vengan del Excel
@@ -92,7 +96,10 @@ test('Crear trackings en la sede Lima en una sola petición (batch)', async () =
     body.idOficina = idOficina
     body.direccionEntrega = fila['DIRECCIONES']
     body.consignado = 'Pruebas Alem Origen Lima'
-    body.idUbigeo = parseInt(fila['IDUBIGEO']) || 0
+
+    const codUbigeo = fila['IDUBIGEO'].toString().padStart(6, '0')
+    expect(codUbigeo.length).toBe(6)
+    body.idUbigeo = parseInt(codUbigeo) || 0
 
     return body
   })

--- a/tests/api/validacionDireccionesNoGeorreferenciadas/validacionAddressIdIteracion.spec.ts
+++ b/tests/api/validacionDireccionesNoGeorreferenciadas/validacionAddressIdIteracion.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { Geo } from '../../../src/apiProviders/geo'
-import { exportarResultadosValidarAddressIdAExcel, leerDatosDesdeExcel } from '@/utils/helpers'
+import { exportarResultadosGenerico, leerDatosDesdeExcel } from '@/utils/helpers'
 import { validarDatosExcel } from '@/utils/validadores'
 import { ExcelValidacion } from '@/types/excelInterfaces'
 
@@ -97,7 +97,21 @@ test('Validar direcciónes no georreferenciadas (address_id = 0)', async () => {
   console.log(`📊 Resumen: ${totalRegistros} procesados, ${exitosos} encontrados, ${direccionesNoEncontradas} no encontradas`)
   console.log(`Hay ${exitosos} de ${totalRegistros} direcciones con address_id = 0 que fueron georreferenciadas correctamente.`)
   // ✅ Exportar al final
-  exportarResultadosValidarAddressIdAExcel(resultadosValidacion, 'resultados_validacion_address_id')
+  exportarResultadosGenerico<ExcelValidacion>({
+    data: resultadosValidacion,
+    nombreBase: 'resultados_validacion_address_id',
+    headers: ['NRO', 'DIRECCIÓN ENVIADA', 'DIRECCIÓN OBTENIDA', 'UBIGEO', 'POLÍGONO OBTENIDO', 'TRACKING', 'SERVICIO CÓDIGO', 'NOMBRE CLIENTE'],
+    extraerCampos: [
+      (r) => r.nro,
+      (r) => r.direccionEnviada,
+      (r) => r.direccionObtenida,
+      (r) => r.ubigeo,
+      (r) => r.poligonoObtenido,
+      (r) => r.tracking,
+      (r) => r.servicioCodigo,
+      (r) => r.nombreCliente
+    ]
+  })
 
   expect(direccionesNoEncontradas).toBe(totalRegistros)
 })


### PR DESCRIPTION
Replaces specific Excel export functions with a generic exportarResultadosGenerico utility for flexible data export. Updates related test files to use the new export function. Adds a new test for validating office geocoding. Improves ubigeo code formatting in tracking creation tests. Updates .gitignore to include .DS_Store.