### PR TITLE
PIT-13: Add getGeoCodeId method and new polygon validation test

### DIFF
--- a/src/apiProviders/geo.ts
+++ b/src/apiProviders/geo.ts
@@ -37,4 +37,14 @@ export class Geo {
 
     return geoReverseResponse
   }
+
+  public async getGeoCodeId(addressId: string) {
+    const geoCodeIdResponse = await this.baseUrl!.get('/api/v2/geo/code', {
+      params: {
+        addressId
+      }
+    })
+
+    return geoCodeIdResponse
+  }
 }


### PR DESCRIPTION
Added the getGeoCodeId method to the Geo API provider for retrieving geocode data by address ID. Fixed a bug in the existing polygon validation test to correctly assign the obtained polygon. Introduced a new test to validate polygons using suggested addresses, including result export and summary reporting.