### PR TITLE
PIT-13: Añadir Testcse 'Validación de normalización de direcciones a través de trackings extraídos con Prisma ORM'

### DIFF
--- a/.env
+++ b/.env
@@ -6,13 +6,13 @@ CI=false
 BASE_URL=https://practicetestautomation.com
 
 # Database Configuration
-DATABASE_URL="prisma+postgres://localhost:51213/?api_key=eyJkYXRhYmFzZVVybCI6InBvc3RncmVzOi8vcG9zdGdyZXM6cG9zdGdyZXNAbG9jYWxob3N0OjUxMjE0L3RlbXBsYXRlMT9zc2xtb2RlPWRpc2FibGUmY29ubmVjdGlvbl9saW1pdD0xJmNvbm5lY3RfdGltZW91dD0wJm1heF9pZGxlX2Nvbm5lY3Rpb25fbGlmZXRpbWU9MCZwb29sX3RpbWVvdXQ9MCZzaW5nbGVfdXNlX2Nvbm5lY3Rpb25zPXRydWUmc29ja2V0X3RpbWVvdXQ9MCIsIm5hbWUiOiJkZWZhdWx0Iiwic2hhZG93RGF0YWJhc2VVcmwiOiJwb3N0Z3JlczovL3Bvc3RncmVzOnBvc3RncmVzQGxvY2FsaG9zdDo1MTIxNS90ZW1wbGF0ZTE_c3NsbW9kZT1kaXNhYmxlJmNvbm5lY3Rpb25fbGltaXQ9MSZjb25uZWN0X3RpbWVvdXQ9MCZtYXhfaWRsZV9jb25uZWN0aW9uX2xpZmV0aW1lPTAmcG9vbF90aW1lb3V0PTAmc2luZ2xlX3VzZV9jb25uZWN0aW9ucz10cnVlJnNvY2tldF90aW1lb3V0PTAifQ"
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=qa_automation_db
-DB_USER=username
-DB_PASSWORD=password
-DB_SCHEMA=public
+DATABASE_URL="jdbc:postgresql://10.136.0.2:5444/address_dev"
+DB_HOST='10.136.0.2'
+DB_PORT=5444
+DB_NAME='address_dev'
+DB_USER='usr_address_read'
+DB_PASSWORD='DWHXTBUi8ZlpvjunPkme6C'
+DB_SCHEMA='olva'
 
 # Test Data
 TEST_USERNAME=student

--- a/.env
+++ b/.env
@@ -5,14 +5,14 @@ CI=false
 # Application URLs
 BASE_URL=https://practicetestautomation.com
 
-# Database Configuration
-DATABASE_URL="jdbc:postgresql://10.136.0.2:5444/address_dev"
-DB_HOST='10.136.0.2'
-DB_PORT=5444
-DB_NAME='address_dev'
-DB_USER='usr_address_read'
-DB_PASSWORD='DWHXTBUi8ZlpvjunPkme6C'
-DB_SCHEMA='olva'
+# Database Configuration // Solicitarlo internamente
+DATABASE_URL=''
+DB_HOST=''
+DB_PORT=
+DB_NAME=''
+DB_USER=''
+DB_PASSWORD=''
+DB_SCHEMA=''
 
 # Test Data
 TEST_USERNAME=student

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 /resultados-exportados/
 
 .DS_Store
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^6.13.0",
+        "@prisma/client": "^6.14.0",
         "dotenv": "^17.2.1",
         "prisma": "^6.13.0",
         "xlsx": "^0.18.5"
@@ -21,29 +21,6 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.1.4",
         "typescript": "^5.9.2"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -227,9 +204,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.13.0.tgz",
-      "integrity": "sha512-8m2+I3dQovkV8CkDMluiwEV1TxV9EXdT6xaCz39O6jYw7mkf5gwfmi+cL4LJsEPwz5tG7sreBwkRpEMJedGYUQ==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.14.0.tgz",
+      "integrity": "sha512-8E/Nk3eL5g7RQIg/LUj1ICyDmhD053STjxrPxUtCRybs2s/2sOEcx9NpITuAOPn07HEpWBfhAVe1T/HYWXUPOw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -249,60 +226,60 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.13.0.tgz",
-      "integrity": "sha512-OYMM+pcrvj/NqNWCGESSxVG3O7kX6oWuGyvufTUNnDw740KIQvNyA4v0eILgkpuwsKIDU36beZCkUtIt0naTog==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.14.0.tgz",
+      "integrity": "sha512-IwC7o5KNNGhmblLs23swnfBjADkacBb7wvyDXUWLwuvUQciKJZqyecU0jw0d7JRkswrj+XTL8fdr0y2/VerKQQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
         "effect": "3.16.12",
-        "read-package-up": "11.0.0"
+        "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.13.0.tgz",
-      "integrity": "sha512-um+9pfKJW0ihmM83id9FXGi5qEbVJ0Vxi1Gm0xpYsjwUBnw6s2LdPBbrsG9QXRX46K4CLWCTNvskXBup4i9hlw==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.14.0.tgz",
+      "integrity": "sha512-j4Lf+y+5QIJgQD4sJWSbkOD7geKx9CakaLp/TyTy/UDu9Wo0awvWCBH/BAxTHUaCpIl9USA5VS/KJhDqKJSwug==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.13.0.tgz",
-      "integrity": "sha512-D+1B79LFvtWA0KTt8ALekQ6A/glB9w10ETknH5Y9g1k2NYYQOQy93ffiuqLn3Pl6IPJG3EsK/YMROKEaq8KBrA==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.14.0.tgz",
+      "integrity": "sha512-LhJjqsALFEcoAtF07nSaOkVguaxw/ZsgfROIYZ8bAZDobe7y8Wy+PkYQaPOK1iLSsFgV2MhCO/eNrI1gdSOj6w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.13.0",
-        "@prisma/engines-version": "6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd",
-        "@prisma/fetch-engine": "6.13.0",
-        "@prisma/get-platform": "6.13.0"
+        "@prisma/debug": "6.14.0",
+        "@prisma/engines-version": "6.14.0-25.717184b7b35ea05dfa71a3236b7af656013e1e49",
+        "@prisma/fetch-engine": "6.14.0",
+        "@prisma/get-platform": "6.14.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd.tgz",
-      "integrity": "sha512-MpPyKSzBX7P/ZY9odp9TSegnS/yH3CSbchQE9f0yBg3l2QyN59I6vGXcoYcqKC9VTniS1s18AMmhyr1OWavjHg==",
+      "version": "6.14.0-25.717184b7b35ea05dfa71a3236b7af656013e1e49",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.14.0-25.717184b7b35ea05dfa71a3236b7af656013e1e49.tgz",
+      "integrity": "sha512-EgN9ODJpiX45yvwcngoStp3uQPJ3l+AEVoQ6dMMO2QvmwIlnxfApzKmJQExzdo7/hqQANrz5txHJdGYHzOnGHA==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.13.0.tgz",
-      "integrity": "sha512-grmmq+4FeFKmaaytA8Ozc2+Tf3BC8xn/DVJos6LL022mfRlMZYjT3hZM0/xG7+5fO95zFG9CkDUs0m1S2rXs5Q==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.14.0.tgz",
+      "integrity": "sha512-MPzYPOKMENYOaY3AcAbaKrfvXVlvTc6iHmTXsp9RiwCX+bPyfDMqMFVUSVXPYrXnrvEzhGHfyiFy0PRLHPysNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.13.0",
-        "@prisma/engines-version": "6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd",
-        "@prisma/get-platform": "6.13.0"
+        "@prisma/debug": "6.14.0",
+        "@prisma/engines-version": "6.14.0-25.717184b7b35ea05dfa71a3236b7af656013e1e49",
+        "@prisma/get-platform": "6.14.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.13.0.tgz",
-      "integrity": "sha512-Nii2pX50fY4QKKxQwm7/vvqT6Ku8yYJLZAFX4e2vzHwRdMqjugcOG5hOSLjxqoXb0cvOspV70TOhMzrw8kqAnw==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.14.0.tgz",
+      "integrity": "sha512-7VjuxKNwjnBhKfqPpMeWiHEa2sVjYzmHdl1slW6STuUCe9QnOY0OY1ljGSvz6wpG4U8DfbDqkG1yofd/1GINww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.13.0"
+        "@prisma/debug": "6.14.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -312,20 +289,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
-    },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "license": "MIT"
     },
     "node_modules/adler-32": {
       "version": "1.3.1",
@@ -635,6 +606,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -696,18 +676,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-up-simple": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
-      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/frac": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
@@ -762,18 +730,6 @@
         "giget": "dist/cli.mjs"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -788,18 +744,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/index-to-position": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
-      "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -834,12 +778,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -854,13 +792,13 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.4.tgz",
-      "integrity": "sha512-xy7rnzQrhTVGKMpv6+bmIA3C0yET31x8OhKBYfvGo0/byeZ6E0BjGARrir3Kg/RhhYHutpsi01+2J5IpfVoueA==",
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.5.tgz",
+      "integrity": "sha512-uAeQQwByI6dfV7wpt/gVqg+jAPaSp8WwOA8kKC/dv1qw14oGpnpAisY65ibGHUGDUv0rYaZ8CAJZ/1U8hUvC2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
+        "chalk": "^5.5.0",
         "commander": "^14.0.0",
         "debug": "^4.4.1",
         "lilconfig": "^3.1.3",
@@ -869,7 +807,7 @@
         "nano-spawn": "^1.0.2",
         "pidtree": "^0.6.0",
         "string-argv": "^0.3.2",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.1"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -952,12 +890,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -1006,24 +938,10 @@
       }
     },
     "node_modules/node-fetch-native": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-      "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
-    },
-    "node_modules/normalize-package-data": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
     },
     "node_modules/nypm": {
       "version": "0.6.1",
@@ -1066,23 +984,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-json": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "index-to-position": "^1.1.0",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1094,12 +995,6 @@
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1171,14 +1066,14 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.13.0.tgz",
-      "integrity": "sha512-dfzORf0AbcEyyzxuv2lEwG8g+WRGF/qDQTpHf/6JoHsyF5MyzCEZwClVaEmw3WXcobgadosOboKUgQU0kFs9kw==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.14.0.tgz",
+      "integrity": "sha512-QEuCwxu+Uq9BffFw7in8In+WfbSUN0ewnaSUKloLkbJd42w6EyFckux4M0f7VwwHlM3A8ssaz4OyniCXlsn0WA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.13.0",
-        "@prisma/engines": "6.13.0"
+        "@prisma/config": "6.14.0",
+        "@prisma/engines": "6.14.0"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -1221,42 +1116,6 @@
         "destr": "^2.0.3"
       }
     },
-    "node_modules/read-package-up": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
-      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up-simple": "^1.0.0",
-        "read-pkg": "^9.0.0",
-        "type-fest": "^4.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.3",
-        "normalize-package-data": "^6.0.0",
-        "parse-json": "^8.0.0",
-        "type-fest": "^4.6.0",
-        "unicorn-magic": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1294,18 +1153,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -1335,38 +1182,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
-      "license": "CC0-1.0"
     },
     "node_modules/ssf": {
       "version": "0.11.2",
@@ -1443,18 +1258,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -1470,33 +1273,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
     },
     "node_modules/wmf": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prepare": "husky",
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
+    "prisma:generate": "npx prisma generate",
     "tsc": "tsc"
   },
   "lint-staged": {
@@ -21,7 +22,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@prisma/client": "^6.13.0",
+    "@prisma/client": "^6.14.0",
     "dotenv": "^17.2.1",
     "prisma": "^6.13.0",
     "xlsx": "^0.18.5"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,10 +6,46 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+}
+
+model OlvaTrackings {
+  id                  Int      @id
+  id_envio            Int      @unique
+  address_id          Int
+  emision             Int
+  tracking            Int
+  address             String
+  ubigeo              String?
+  cliente             Int
+  orden_servicio      String
+  fecha_emision       DateTime
+  geocode             Boolean
+  contenedor          String
+  servicio_codigo     String
+  status              Int
+  nombre_cliente      String
+  documento_client    String
+  centro_costo        String
+  id_operador         Int
+  codigo_operador     String
+  id_sede             Int
+  nombre_sede         String
+  id_persona_jur_area Int
+  sector_direccion    String
+  tracking_tipo       String
+  created_at          Float
+  updated_at          Float
+  created_by          Int
+  updated_by          Int
+  start_geocode       Int
+  address_normalized  String
+  address_problems    Json
+  address_token       String
+
+  @@map("trackings")
 }

--- a/src/apiProviders/geo.ts
+++ b/src/apiProviders/geo.ts
@@ -1,5 +1,5 @@
 import { request, APIRequestContext } from '@playwright/test'
-import { environment } from '@config/environment'
+import { environment } from '../config/environment'
 
 export class Geo {
   private baseUrl?: APIRequestContext

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { config } from 'dotenv'
-import { parseBoolean, parseNumber } from '@/utils/helpers'
+import { parseBoolean, parseNumber } from '../utils/helpers'
 
 // Load environment variables from .env file
 config({ path: path.resolve(process.cwd(), '.env') })
@@ -74,6 +74,9 @@ export interface EnvironmentConfig {
   geoXApiKey: string
 }
 
+// ✅ Composición segura de DATABASE_URL
+const databaseUrl = `postgresql://${process.env.DB_USER}:${process.env.DB_PASSWORD}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}?schema=${process.env.DB_SCHEMA}`
+
 /**
  * Environment configuration object
  */
@@ -83,7 +86,7 @@ export const environment: EnvironmentConfig = {
   baseUrl: process.env.BASE_URL!, // is obtained from the .env file
 
   database: {
-    url: process.env.DATABASE_URL!,
+    url: databaseUrl, // es la composición segura de DB
     host: process.env.DB_HOST || 'localhost', // is obtained from the .env file
     port: parseNumber(process.env.DB_PORT, 5432),
     name: process.env.DB_NAME || 'qa_automation_db',

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,0 +1,82 @@
+import { PrismaClient } from '@prisma/client'
+import { environment as config } from '../config/environment'
+
+/**
+ * Database connection singleton
+ * Manages the Prisma client instance for database operations
+ */
+class DatabaseConnection {
+  private static instance: DatabaseConnection
+  private prisma: PrismaClient
+
+  private constructor() {
+    this.prisma = new PrismaClient({
+      log: config.environment === 'development' ? ['query', 'info', 'warn', 'error'] : ['error'],
+      datasources: {
+        db: {
+          url: config.database.url
+        }
+      }
+    })
+  }
+
+  /**
+   * Get the singleton instance of DatabaseConnection
+   */
+  public static getInstance(): DatabaseConnection {
+    if (!DatabaseConnection.instance) {
+      DatabaseConnection.instance = new DatabaseConnection()
+    }
+    return DatabaseConnection.instance
+  }
+
+  /**
+   * Get the Prisma client instance
+   */
+  public getClient(): PrismaClient {
+    return this.prisma
+  }
+
+  /**
+   * Connect to the database
+   */
+  public async connect(): Promise<void> {
+    try {
+      await this.prisma.$connect()
+      console.log('✅ Database connected successfully')
+    } catch (error) {
+      console.error('❌ Database connection failed:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Disconnect from the database
+   */
+  public async disconnect(): Promise<void> {
+    try {
+      await this.prisma.$disconnect()
+      console.log('✅ Database disconnected successfully')
+    } catch (error) {
+      console.error('❌ Database disconnection failed:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Check database connection health
+   */
+  public async healthCheck(): Promise<boolean> {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`
+      return true
+    } catch (error) {
+      console.error('❌ Database health check failed:', error)
+      return false
+    }
+  }
+}
+
+// Export singleton instance
+export const database = DatabaseConnection.getInstance()
+export const prisma = database.getClient()

--- a/src/database/testDataHelpers.ts
+++ b/src/database/testDataHelpers.ts
@@ -3,15 +3,22 @@ import { trackingData } from '../types/dataBaseInterfaces'
 import { prisma } from './connection'
 
 /**
- * Get all trackings by date
+ * Get all trackings by date (using greater than, like your SQL)
  */
 export async function getTrakingsByDate(
   trackingData: trackingData
 ): Promise<Pick<OlvaTrackings, 'tracking' | 'address_id' | 'address' | 'address_normalized'>[]> {
   try {
+    console.log('🔍 Executing query with parameters:')
+    console.log(`   fecha_emision > ${trackingData.fecha_emision.toISOString()}`)
+    console.log(`   emision = ${trackingData.emision}`)
+    console.log(`   limit = ${trackingData.limit}`)
+
     return await prisma.olvaTrackings.findMany({
       where: {
-        fecha_emision: trackingData.fecha_emision,
+        fecha_emision: {
+          gt: trackingData.fecha_emision // Using 'gt' (greater than) instead of equality
+        },
         emision: trackingData.emision
       },
       select: {
@@ -26,5 +33,78 @@ export async function getTrakingsByDate(
   } catch (error) {
     console.error('Error fetching trackings by date:', error)
     return []
+  }
+}
+
+/**
+ * Execute the exact same SQL query you're using in DBeaver
+ *
+ * Prisma Raw Query Options:
+ *
+ * 1. $queryRaw - For SELECT queries (returns array of objects)
+ * 2. $executeRaw - For INSERT/UPDATE/DELETE (returns count)
+ * 3. $queryRawUnsafe - When you need dynamic SQL (less safe)
+ * 4. $executeRawUnsafe - For non-SELECT dynamic SQL
+ */
+export async function getTrakingsByDateRawSQL() {
+  try {
+    console.log('🔍 Executing raw SQL query (same as DBeaver):')
+
+    // Option 1: Template literal (recommended - SQL injection safe)
+    const result = await prisma.$queryRaw`
+      SELECT t.tracking, t.address_id, t.address, t.address_normalized, t.address_problems
+      FROM olva.trackings t
+      WHERE t.fecha_emision > '2025-06-23T00:00:00.000Z'
+        AND t.emision = '25'
+      ORDER BY t.tracking DESC
+      LIMIT 5
+    `
+
+    console.log(`Raw SQL returned ${Array.isArray(result) ? result.length : 0} records`)
+    return result
+  } catch (error) {
+    console.error('Error executing raw SQL:', error)
+    return []
+  }
+}
+
+/**
+ * Example with parameters (safer for dynamic values)
+ */
+export async function getTrakingsByDateWithParams(fechaDesde: Date, emisionValue: number, limitValue: number) {
+  try {
+    // Using parameters to prevent SQL injection
+    const result = await prisma.$queryRaw`
+      SELECT t.tracking, t.address_id, t.address, t.address_normalized, t.address_problems
+      FROM olva.trackings t
+      WHERE t.fecha_emision > ${fechaDesde}
+        AND t.emision = ${emisionValue.toString()}
+      ORDER BY t.tracking DESC
+      LIMIT ${limitValue}
+    `
+
+    return result
+  } catch (error) {
+    console.error('Error executing parameterized raw SQL:', error)
+    return []
+  }
+}
+
+/**
+ * Example for COUNT queries
+ */
+export async function getTrackingsCount(fechaDesde: Date, emisionValue: number) {
+  try {
+    const result = await prisma.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(*) as count
+      FROM olva.trackings t
+      WHERE t.fecha_emision > ${fechaDesde}
+        AND t.emision = ${emisionValue.toString()}
+    `
+
+    return Number(result[0].count)
+  } catch (error) {
+    console.error('Error executing count query:', error)
+    return 0
   }
 }

--- a/src/database/testDataHelpers.ts
+++ b/src/database/testDataHelpers.ts
@@ -1,0 +1,30 @@
+import { OlvaTrackings } from '@prisma/client'
+import { trackingData } from '../types/dataBaseInterfaces'
+import { prisma } from './connection'
+
+/**
+ * Get all trackings by date
+ */
+export async function getTrakingsByDate(
+  trackingData: trackingData
+): Promise<Pick<OlvaTrackings, 'tracking' | 'address_id' | 'address' | 'address_normalized'>[]> {
+  try {
+    return await prisma.olvaTrackings.findMany({
+      where: {
+        fecha_emision: trackingData.fecha_emision,
+        emision: trackingData.emision
+      },
+      select: {
+        tracking: true,
+        address_id: true,
+        address: true,
+        address_normalized: true
+      },
+      orderBy: { tracking: 'desc' },
+      take: trackingData.limit
+    })
+  } catch (error) {
+    console.error('Error fetching trackings by date:', error)
+    return []
+  }
+}

--- a/src/types/dataBaseInterfaces.ts
+++ b/src/types/dataBaseInterfaces.ts
@@ -1,0 +1,7 @@
+import { StringifyOptions } from 'querystring'
+
+export interface trackingData {
+  fecha_emision: Date
+  emision: number
+  limit: number
+}

--- a/src/types/excelInterfaces.ts
+++ b/src/types/excelInterfaces.ts
@@ -30,3 +30,12 @@ export interface ExportConfig<T> {
 }
 
 export type CampoExtractor<T> = (item: T) => string | number | boolean | undefined
+
+// Interfaz para el Excel, adaptada a tu función exportarResultadosGenerico
+export interface ExcelValidacionExportTrackings {
+  tracking: number
+  address_id: number
+  address: string
+  address_normalized: string
+  errores: string
+}

--- a/src/types/validacionInterfaces.ts
+++ b/src/types/validacionInterfaces.ts
@@ -1,0 +1,7 @@
+export interface ValidationResult {
+  tracking: number
+  address_id: number
+  address: string
+  address_normalized: string
+  errors: string[]
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import * as XLSX from 'xlsx'
 import * as fs from 'fs'
 import * as path from 'path'
-import { ExcelValidacion, ExportConfig } from '@/types/excelInterfaces'
+import { ExcelValidacion, ExportConfig } from '../types/excelInterfaces'
 
 export function parseNumber(value: string | undefined, defaultValue: number): number {
   const parsed = Number(value)

--- a/src/utils/validadores.ts
+++ b/src/utils/validadores.ts
@@ -1,4 +1,23 @@
+import { ExcelValidacionExportTrackings } from '@/types/excelInterfaces'
 import { expect } from '@playwright/test'
+import { OlvaTrackings } from '@prisma/client' // Importamos el tipo de dato de Prisma
+
+// Definiciones de datos
+const ciudadesConocidas = ['tacna', 'pocollay', 'lima', 'arequipa', 'miraflores', 'san isidro']
+const manzanasLotes = ['lt', 'mz', 'lot', 'lte', 'manz', 'mzn', 'km', 'secto']
+const caracteresEspeciales = ['!', '@', '#', '$', '%', '&', '*', '/', '\\', 'ª', 'º', '©', '³', '±']
+const erroresTipograficos = new Map<string, string>([
+  ['av', 'avenida'],
+  ['jr', 'jiron'],
+  ['clle', 'calle'],
+  ['cl', 'calle'],
+  ['cale', 'calle'],
+  ['mz', 'manzana'],
+  ['maz', 'manzana'],
+  ['lte', 'lote'],
+  ['urb', 'urbanizacion'],
+  ['lt', 'lote']
+])
 
 /**
  * Valida que una lista de datos leída desde un archivo Excel no esté vacía.
@@ -9,4 +28,160 @@ export function validarDatosExcel(datos: any[], sheetName: string) {
   expect(datos.length).toBeGreaterThan(0)
 
   console.log(`✅ Excel '${sheetName}' tiene ${datos.length} registros.`)
+}
+
+export function clasificarErrores(direccionOriginal: string, direccionNormalizada: string): string[] {
+  const errores: string[] = []
+
+  const original = direccionOriginal?.toLowerCase()?.trim() || ''
+  const normalizada = direccionNormalizada?.toLowerCase()?.trim() || ''
+
+  if (!original || original.length < 8) {
+    return ['Dirección vacía o demasiado corta']
+  }
+
+  // === VALIDACIÓN DE GUION Y TEXTO POSTERIOR ===
+  const palabrasClave = ['avenida', 'calle', 'jiron', 'jirón', 'manzana', 'lote', 'urbanización', 'jr', 'av', 'mz', 'ca.']
+
+  let direccionBase = original
+  let direccionNormalizadaBase = normalizada
+
+  if (original.includes('-')) {
+    const partes = original.split(/\s*-\s*/, 2)
+    const parteIzquierda = partes[0]?.trim()
+    const parteDerecha = partes.length > 1 ? partes[1]?.trim() : ''
+
+    const contienePalabraClave = palabrasClave.some((palabra) => parteIzquierda.includes(palabra))
+
+    if (contienePalabraClave && parteDerecha) {
+      const normalizadaMinuscula = normalizada.toLowerCase()
+      const textoPosterior = parteDerecha.toLowerCase()
+
+      // 🛡️ EXCEPCIONES PERMITIDAS
+      const excepcionesValidas = [
+        /[a-záéíóúñ]+\-\d+/, // ej: manzana-4, lt-1, mz-4
+        /\d+\-\d+/, // ej: 123-125
+        /[a-záéíóúñ]+\-[a-záéíóúñ]+/ // ej: san-juan
+      ]
+
+      const esExcepcionValida = excepcionesValidas.some((regex) => normalizadaMinuscula.match(regex))
+
+      const guionPersistente = normalizadaMinuscula.includes(' - ')
+      const textoPersistente = textoPosterior.split(/\s+/).some((palabra) => normalizadaMinuscula.includes(palabra))
+
+      if (!esExcepcionValida && (guionPersistente || textoPersistente)) {
+        errores.push(`No se eliminó texto posterior al guion o el guion mismo: '- ${parteDerecha}'`)
+      }
+
+      if (!esExcepcionValida) {
+        direccionBase = parteIzquierda
+        const partesNormalizada = direccionNormalizada.split(/\s*-\s*/)
+        direccionNormalizadaBase = partesNormalizada[0]?.trim()
+      }
+    }
+  }
+
+  // VALIDACIONES ADICIONALES
+  if (direccionBase.includes('@') && direccionNormalizadaBase.includes('@')) {
+    errores.push('Dirección con correo electrónico')
+  }
+
+  const phoneRegex = /\b\d{6,}\b/
+  if (original.match(phoneRegex) && normalizada.match(phoneRegex)) {
+    errores.push('Contiene número telefónico')
+  }
+
+  ciudadesConocidas.forEach((ciudad) => {
+    if (original.startsWith(ciudad) && normalizada.startsWith(ciudad)) {
+      errores.push(`Inicia con nombre de ciudad: ${ciudad}`)
+    }
+  })
+
+  const institutionalRegex = /(aa\.?hh|asoc|a\.h\.|municipalid|ministeri|fiscali|condominio|cooperativ)/
+  if (original.match(institutionalRegex) && normalizada.match(institutionalRegex)) {
+    errores.push('Dirección institucional o de asentamiento')
+  }
+
+  manzanasLotes.forEach((termino) => {
+    const pattern = new RegExp(`\\b${termino}\\b`, 'i')
+    if (original.match(pattern) && normalizada.match(pattern)) {
+      errores.push(`Contiene término de lote/manzana: ${termino}`)
+    }
+  })
+
+  const noNumberRegex = /\b\d{1,4}\b/
+  if (
+    (original.includes('s/n') || original.includes('nro null') || !original.match(noNumberRegex)) &&
+    (normalizada.includes('s/n') || normalizada.includes('nro null') || !normalizada.match(noNumberRegex))
+  ) {
+    errores.push('Dirección sin número')
+  }
+
+  const duplicatedRegex = /\b(\w+)\s+\1\b/
+  if (original.match(duplicatedRegex) && normalizada.match(duplicatedRegex)) {
+    errores.push('Palabra o número duplicado')
+  }
+
+  if (original.includes('referencia') && normalizada.includes('referencia')) {
+    errores.push("Contiene palabra 'referencia'")
+  }
+
+  caracteresEspeciales.forEach((char) => {
+    if (original.includes(char) && normalizada.includes(char)) {
+      errores.push(`Caracter especial: ${char}`)
+    }
+  })
+
+  erroresTipograficos.forEach((esperado, originalTypo) => {
+    const patternOriginal = new RegExp(`\\b${originalTypo}\\b`, 'i')
+    if (original.match(patternOriginal) && !normalizada.includes(esperado)) {
+      errores.push(`No se normalizó '${originalTypo}' a '${esperado}'`)
+    }
+  })
+
+  return errores
+}
+
+/**
+ * Función principal para validar un array de trackings.
+ * @param trackings - Array de objetos OlvaTrackings obtenidos de Prisma.
+ * @returns Un array de resultados de validación.
+ */
+export function validarTrackings(
+  trackings: Pick<OlvaTrackings, 'tracking' | 'address_id' | 'address' | 'address_normalized'>[]
+): ExcelValidacionExportTrackings[] {
+  const resultados: ExcelValidacionExportTrackings[] = []
+
+  trackings.forEach((tracking) => {
+    const errores: string[] = []
+
+    const original = tracking.address?.toLowerCase()?.trim() || ''
+    const normalizada = tracking.address_normalized?.toLowerCase()?.trim() || ''
+
+    // === VALIDACIONES INICIALES (que me faltó incluir) ===
+    if (tracking.address_id === 0) {
+      errores.push('No georreferenciado')
+    }
+    if (original === normalizada) {
+      errores.push('Sin normalización visible')
+    }
+
+    // Llama a la función de clasificación solo si la dirección tiene contenido
+    if (original) {
+      const erroresAdicionales = clasificarErrores(tracking.address, tracking.address_normalized)
+      errores.push(...erroresAdicionales)
+    } else {
+      errores.push('Dirección vacía')
+    }
+
+    resultados.push({
+      tracking: tracking.tracking,
+      address_id: tracking.address_id,
+      address: tracking.address || '',
+      address_normalized: tracking.address_normalized || '',
+      errores: errores.length > 0 ? errores.join('; ') : 'Correcta'
+    })
+  })
+
+  return resultados
 }

--- a/tests/api/creacionTrancking/crearTrackingsLima.spec.ts
+++ b/tests/api/creacionTrancking/crearTrackingsLima.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { EnvioRest } from '@/apiProviders/envioRest'
 import crearEnvioBodyJson from '@/testData/archivosJson/crearEnvioBody.json'
 import { TipoCiudad, typeCiudad } from '@/config/ciudades'
-import { leerDatosDesdeExcel } from '@/utils/helpers'
+import { leerDatosDesdeExcel } from '../../../src/utils/helpers'
 import { validarDatosExcel } from '@/utils/validadores'
 
 let envioRest: EnvioRest

--- a/tests/api/validacionDesdeBD/validacionNormalizacionDirecciones.spec.ts
+++ b/tests/api/validacionDesdeBD/validacionNormalizacionDirecciones.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { getTrakingsByDate } from '../../../src/database/testDataHelpers'
+import { getTrakingsByDate, getTrakingsByDateRawSQL } from '../../../src/database/testDataHelpers'
 import { database } from '../../../src/database/connection'
 
 test.describe('Pruebas con base de datos', () => {
@@ -14,11 +14,117 @@ test.describe('Pruebas con base de datos', () => {
     await database.disconnect()
   })
 
-  test('Consulta de usuarios', async () => {
+  test('Consulta de trackings utilizando Prisma ORM', async () => {
+    console.log('\n=== Testing Prisma ORM query ===')
     // Create a proper ISO-8601 datetime string for the database query
     const fechaConsulta = new Date('2025-06-23T00:00:00.000Z')
-    const trackings = await getTrakingsByDate({ fecha_emision: fechaConsulta, emision: 25, limit: 5 })
-    console.log(`Found ${trackings.length} trackings`)
-    // expect(trackings.length).toBeGreaterThan(0)
+    const limit = 5
+    const trackings = await getTrakingsByDate({ fecha_emision: fechaConsulta, emision: 25, limit })
+    console.log(`Prisma ORM found ${trackings.length} trackings`)
+
+    // ✅ Validaciones para Prisma ORM
+    expect(trackings).toBeInstanceOf(Array)
+    expect(trackings.length).toBeGreaterThan(0) // Al menos 1 tracking
+
+    // ✅ Validar estructura de datos de Prisma
+    if (trackings.length > 0) {
+      const firstTracking = trackings[0]
+
+      // Verificar propiedades del tipo Prisma
+      expect(firstTracking).toHaveProperty('tracking')
+      expect(firstTracking).toHaveProperty('address_id')
+      expect(firstTracking).toHaveProperty('address')
+      expect(firstTracking).toHaveProperty('address_normalized')
+    }
+  })
+
+  test('Consulta de trackings utilizando Raw SQL', async () => {
+    console.log('\n=== Testing Raw SQL query (same as DBeaver) ===')
+    const rawResults = await getTrakingsByDateRawSQL()
+    console.log(`Raw SQL found ${Array.isArray(rawResults) ? rawResults.length : 0} trackings`)
+
+    if (Array.isArray(rawResults) && rawResults.length > 0) {
+      console.log('Sample raw result:', rawResults[0])
+    }
+
+    // ✅ Validaciones básicas de cantidad
+    expect(rawResults).toBeInstanceOf(Array)
+    const results = rawResults as any[] // Type assertion para trabajar con el array
+    expect(results.length).toBeGreaterThan(0) // Al menos 1 tracking
+    expect(results.length).toBeLessThanOrEqual(5) // No más del límite
+
+    // ✅ Validación exacta si sabes cuántos esperas
+    // expect(rawResults.length).toBe(5) // Exactamente 5 trackings
+
+    // ✅ Validaciones de estructura de datos
+    if (results.length > 0) {
+      const firstResult = results[0] as any
+
+      // Verificar que tiene las propiedades esperadas
+      expect(firstResult).toHaveProperty('tracking')
+      expect(firstResult).toHaveProperty('address_id')
+      expect(firstResult).toHaveProperty('address')
+      expect(firstResult).toHaveProperty('address_normalized')
+      expect(firstResult).toHaveProperty('address_problems')
+
+      // Verificar tipos de datos
+      expect(typeof firstResult.tracking).toBe('bigint') // PostgreSQL BIGINT
+      expect(typeof firstResult.address_id).toBe('number')
+      expect(typeof firstResult.address).toBe('string')
+      expect(firstResult.address.length).toBeGreaterThan(0) // No vacío
+
+      // Verificar que tracking es un número válido
+      expect(Number(firstResult.tracking)).toBeGreaterThan(0)
+      expect(firstResult.address_id).toBeGreaterThan(0)
+    }
+
+    // ✅ Validar que todos los resultados tienen datos válidos
+    results.forEach((result: any, index: number) => {
+      expect(result.tracking, `Tracking en índice ${index} debe existir`).toBeDefined()
+      expect(result.address_id, `Address ID en índice ${index} debe ser mayor a 0`).toBeGreaterThan(0)
+      expect(result.address, `Address en índice ${index} no debe estar vacío`).toBeTruthy()
+    })
+  })
+
+  test('Comparar resultados entre Prisma ORM y Raw SQL', async () => {
+    console.log('\n=== Comparing Prisma ORM vs Raw SQL ===')
+
+    const fechaConsulta = new Date('2025-06-23T00:00:00.000Z')
+    const limit = 3 // Usar un límite menor para la comparación
+
+    // Ejecutar ambas queries
+    const prismaResults = await getTrakingsByDate({ fecha_emision: fechaConsulta, emision: 25, limit })
+    const rawResults = (await getTrakingsByDateRawSQL()) as any[]
+
+    console.log(`Prisma: ${prismaResults.length} results, Raw SQL: ${rawResults.length} results`)
+
+    // ✅ Ambos deben devolver datos
+    expect(prismaResults.length).toBeGreaterThan(0)
+    expect(rawResults.length).toBeGreaterThan(0)
+
+    // ✅ Comparar que ambos devuelven el mismo número de registros (si usan el mismo límite)
+    // Note: Raw SQL usa LIMIT 5, Prisma usa el parámetro limit
+    expect(prismaResults.length).toBeLessThanOrEqual(limit)
+    expect(rawResults.length).toBeLessThanOrEqual(5)
+
+    // ✅ Verificar que ambos devuelven los mismos trackings (al menos los primeros)
+    if (prismaResults.length > 0 && rawResults.length > 0) {
+      const prismaFirst = prismaResults[0]
+      const rawFirst = rawResults[0]
+
+      // Los trackings deben coincidir (ambos ordenados por tracking DESC)
+      expect(prismaFirst.tracking).toBe(rawFirst.tracking.toString())
+      expect(prismaFirst.address_id).toBe(rawFirst.address_id)
+      expect(prismaFirst.address).toBe(rawFirst.address)
+    }
+
+    // ✅ Validar que los datos están ordenados correctamente (DESC)
+    if (prismaResults.length > 1) {
+      for (let i = 0; i < prismaResults.length - 1; i++) {
+        const current = BigInt(prismaResults[i].tracking)
+        const next = BigInt(prismaResults[i + 1].tracking)
+        expect(current).toBeGreaterThanOrEqual(next)
+      }
+    }
   })
 })

--- a/tests/api/validacionDesdeBD/validacionNormalizacionDirecciones.spec.ts
+++ b/tests/api/validacionDesdeBD/validacionNormalizacionDirecciones.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+import { getTrakingsByDate } from '../../../src/database/testDataHelpers'
+import { database } from '../../../src/database/connection'
+
+test.describe('Pruebas con base de datos', () => {
+  // Configure no retries for this test suite
+  test.describe.configure({ retries: 0 })
+
+  test.beforeAll(async () => {
+    await database.connect()
+  })
+
+  test.afterAll(async () => {
+    await database.disconnect()
+  })
+
+  test('Consulta de usuarios', async () => {
+    // Create a proper ISO-8601 datetime string for the database query
+    const fechaConsulta = new Date('2025-06-23T00:00:00.000Z')
+    const trackings = await getTrakingsByDate({ fecha_emision: fechaConsulta, emision: 25, limit: 5 })
+    console.log(`Found ${trackings.length} trackings`)
+    // expect(trackings.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/api/validacionDireccionesNoGeorreferenciadas/validacionAddressIdIteracion.spec.ts
+++ b/tests/api/validacionDireccionesNoGeorreferenciadas/validacionAddressIdIteracion.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { Geo } from '../../../src/apiProviders/geo'
-import { exportarResultadosGenerico, leerDatosDesdeExcel } from '@/utils/helpers'
+import { exportarResultadosGenerico, leerDatosDesdeExcel } from '../../../src/utils/helpers'
 import { validarDatosExcel } from '@/utils/validadores'
 import { ExcelValidacion } from '@/types/excelInterfaces'
 

--- a/tests/api/validacionOficinas/validacionGeoCodeOficinas.spec.ts
+++ b/tests/api/validacionOficinas/validacionGeoCodeOficinas.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { Geo } from '../../../src/apiProviders/geo'
-import { exportarResultadosGenerico, leerDatosDesdeExcel } from '@/utils/helpers'
+import { exportarResultadosGenerico, leerDatosDesdeExcel } from '../../../src/utils/helpers'
 import { validarDatosExcel } from '@/utils/validadores'
 import { ExcelValidacion } from '@/types/excelInterfaces'
 

--- a/tests/api/validacionOficinas/validacionInversaOficinas.spec.ts
+++ b/tests/api/validacionOficinas/validacionInversaOficinas.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { Geo } from '../../../src/apiProviders/geo'
-import { exportarResultadosGenerico, leerDatosDesdeExcel } from '@/utils/helpers'
+import { exportarResultadosGenerico, leerDatosDesdeExcel } from '../../../src/utils/helpers'
 import { validarDatosExcel } from '@/utils/validadores'
 import { ExcelValidacion } from '@/types/excelInterfaces'
 

--- a/tests/api/validacionPoligonos/validacionGeoCodePoligonos.spec.ts
+++ b/tests/api/validacionPoligonos/validacionGeoCodePoligonos.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { Geo } from '../../../src/apiProviders/geo'
-import { exportarResultadosGenerico, leerDatosDesdeExcel } from '@/utils/helpers'
+import { exportarResultadosGenerico, leerDatosDesdeExcel } from '../../../src/utils/helpers'
 import { validarDatosExcel } from '@/utils/validadores'
 import { ExcelValidacion } from '@/types/excelInterfaces'
 

--- a/tests/api/validacionPoligonos/validacionXDireccionSugeridaPoligonos.spec.ts
+++ b/tests/api/validacionPoligonos/validacionXDireccionSugeridaPoligonos.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { Geo } from '../../../src/apiProviders/geo'
-import { exportarResultadosGenerico, leerDatosDesdeExcel } from '@/utils/helpers'
+import { exportarResultadosGenerico, leerDatosDesdeExcel } from '../../../src/utils/helpers'
 import { validarDatosExcel } from '@/utils/validadores'
 import { ExcelValidacion } from '@/types/excelInterfaces'
 import { devNull } from 'os'


### PR DESCRIPTION
- Introduces a Prisma-based database connection singleton, helpers for test data retrieval, and TypeScript interfaces for tracking data. Updates environment variable handling for secure DB URL composition, adds a new OlvaTrackings model to the Prisma schema, and refactors test and utility imports for consistency. Also updates dependencies, adds a prisma:generate script, and includes a new test for DB-driven address normalization validation.
- Introduced new helper functions in testDataHelpers.ts for executing raw SQL queries and parameterized queries using Prisma. Updated tests to validate and compare results between Prisma ORM and raw SQL queries, including structure and data consistency checks. Also sanitized database credentials in .env for security.
- Introduces address validation logic in validadores.ts, including error classification for addresses and a function to validate arrays of trackings. Adds new interfaces for validation results and Excel export, updates the test to validate and export results, and fixes an import path in geo.ts.