### PR TITLE
Update API endpoints and test parameters

### DIFF
--- a/src/apiProviders/envioRest.ts
+++ b/src/apiProviders/envioRest.ts
@@ -18,7 +18,7 @@ export class EnvioRest {
   }
 
   public async postLogin(usuario: string, clave: string) {
-    return await this.baseUrl!.get('/usuario/login', {
+    return await this.baseUrl!.post('/envioRest/webresources/usuario/login', {
       data: {
         usuario,
         clave
@@ -46,7 +46,7 @@ export class EnvioRest {
     body.consignado = consignado
     body.idUbigeo = idUbigeo
 
-    const getResponse = await this.baseUrl!.get('/envio/crear', {
+    const getResponse = await this.baseUrl!.post('/envioRest/webresources/envio/crear', {
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -57,7 +57,7 @@ export class EnvioRest {
   }
 
   public async postCrearMultiplesEnvios(token: string, listaDeEnvios: CrearEnvioBody[]) {
-    return await this.baseUrl!.post('/envio/crear', {
+    return await this.baseUrl!.post('/envioRest/webresources/envio/crear', {
       data: listaDeEnvios,
       headers: {
         Authorization: `Bearer ${token}`

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import * as XLSX from 'xlsx'
 import * as fs from 'fs'
 import * as path from 'path'
-import { ExcelValidacion, ExportConfig } from '../types/excelInterfaces'
+import { ExportConfig } from '../types/excelInterfaces'
 
 export function parseNumber(value: string | undefined, defaultValue: number): number {
   const parsed = Number(value)

--- a/tests/api/creacionTrancking/crearTrackingsLima.spec.ts
+++ b/tests/api/creacionTrancking/crearTrackingsLima.spec.ts
@@ -8,7 +8,7 @@ import { validarDatosExcel } from '@/utils/validadores'
 let envioRest: EnvioRest
 
 // Configura tu base para códigoOptitrack
-const baseCodigoOptitrack = 50000 // puedes cambiar este valor
+const baseCodigoOptitrack = 50300 // puedes cambiar este valor
 
 // Obtener los IDs de la ciudad actual
 const ciudadActual: TipoCiudad = 'Lima'
@@ -26,7 +26,7 @@ test.beforeEach(async () => {
 })
 
 // 🧪 Test principal con múltiples envíos
-test('Crear trackings en la sede de Lima, 1 request por body (Iterativo)', async () => {
+test('Crear trackings en la sede de Lima, 1 request por body (Iterativo)', async () => { //pendiente de corregir
   // Paso 1: Login
   const loginResponse = await envioRest.postLogin('olvati', 'J&_Mv9]H^2Vx')
   expect(loginResponse.status()).toBe(200)
@@ -41,7 +41,8 @@ test('Crear trackings en la sede de Lima, 1 request por body (Iterativo)', async
   // Validar que el archivo de datos existe y tiene datos
   validarDatosExcel(datos, sheetName)
 
-  for (let i = 0; i < datos.length; i++) {
+  // for (let i = 0; i < datos.length; i++) {
+  for (let i = 0; i < 10; i++) {
     const fila: any = datos[i]
 
     const direccion = fila['DIRECCIONES']
@@ -106,6 +107,8 @@ test('Crear trackings en la sede Lima en una sola petición (batch)', async () =
 
   // Paso 4: Enviar todos los envíos en un solo POST
   const response = await envioRest.postCrearMultiplesEnvios(token, listaEnvios)
+
+  console.log('📦 Respuesta del envío múltiple:', response.body())
 
   expect(response.status()).toBe(201)
 


### PR DESCRIPTION
Changed API endpoint paths in EnvioRest methods to use '/envioRest/webresources/'. Updated test to use a new baseCodigoOptitrack value and limited iteration to 10 items. Removed unused import in helpers.ts.